### PR TITLE
Add explicit 'align()' attributes

### DIFF
--- a/source/libsodium/crypto_aead_aes256gcm.d
+++ b/source/libsodium/crypto_aead_aes256gcm.d
@@ -52,7 +52,7 @@ enum crypto_aead_aes256gcm_MESSAGEBYTES_MAX =
     SODIUM_MIN(SODIUM_SIZE_MAX - crypto_aead_aes256gcm_ABYTES, 16UL * ((1UL << 32) - 2UL));
 size_t crypto_aead_aes256gcm_messagebytes_max ();
 
-struct crypto_aead_aes256gcm_state_
+align(16) struct crypto_aead_aes256gcm_state_
 {
     ubyte[512] opaque;
 }

--- a/source/libsodium/crypto_generichash_blake2b.d
+++ b/source/libsodium/crypto_generichash_blake2b.d
@@ -14,7 +14,7 @@ import libsodium.export_;
 
 extern (C):
 
-struct crypto_generichash_blake2b_state
+align(64) struct crypto_generichash_blake2b_state
 {
     ubyte[384] opaque;
 }

--- a/source/libsodium/crypto_onetimeauth_poly1305.d
+++ b/source/libsodium/crypto_onetimeauth_poly1305.d
@@ -14,7 +14,7 @@ import libsodium.export_;
 
 extern (C):
 
-struct crypto_onetimeauth_poly1305_state
+align(16) struct crypto_onetimeauth_poly1305_state
 {
     ubyte[256] opaque;
 }


### PR DESCRIPTION
Those are hidden behind a macro in libsodium and were just dropped.
It should not affect anything, but better safe than sorry.