### PR TITLE
Add pure attribute and safe wrapper for generic hash

### DIFF
--- a/source/libsodium/crypto_generichash.d
+++ b/source/libsodium/crypto_generichash.d
@@ -16,25 +16,25 @@ import libsodium.crypto_generichash_blake2b;
 extern (C):
 
 enum crypto_generichash_BYTES_MIN = crypto_generichash_blake2b_BYTES_MIN;
-size_t crypto_generichash_bytes_min ();
+size_t crypto_generichash_bytes_min () @safe pure;
 
 enum crypto_generichash_BYTES_MAX = crypto_generichash_blake2b_BYTES_MAX;
-size_t crypto_generichash_bytes_max ();
+size_t crypto_generichash_bytes_max () @safe pure;
 
 enum crypto_generichash_BYTES = crypto_generichash_blake2b_BYTES;
-size_t crypto_generichash_bytes ();
+size_t crypto_generichash_bytes () @safe pure;
 
 enum crypto_generichash_KEYBYTES_MIN = crypto_generichash_blake2b_KEYBYTES_MIN;
-size_t crypto_generichash_keybytes_min ();
+size_t crypto_generichash_keybytes_min () @safe pure;
 
 enum crypto_generichash_KEYBYTES_MAX = crypto_generichash_blake2b_KEYBYTES_MAX;
-size_t crypto_generichash_keybytes_max ();
+size_t crypto_generichash_keybytes_max () @safe pure;
 
 enum crypto_generichash_KEYBYTES = crypto_generichash_blake2b_KEYBYTES;
-size_t crypto_generichash_keybytes ();
+size_t crypto_generichash_keybytes () @safe pure;
 
 enum crypto_generichash_PRIMITIVE = "blake2b";
-const(char)* crypto_generichash_primitive ();
+const(char)* crypto_generichash_primitive () @safe pure;
 
 /*
  * Important when writing bindings for other programming languages:
@@ -42,30 +42,67 @@ const(char)* crypto_generichash_primitive ();
  */
 alias crypto_generichash_state = crypto_generichash_blake2b_state;
 
-size_t crypto_generichash_statebytes ();
+size_t crypto_generichash_statebytes () @safe pure;
 
 int crypto_generichash (
-    ubyte* out_,
+    scope ubyte* out_,
     size_t outlen,
-    const(ubyte)* in_,
+    scope const(ubyte)* in_,
     ulong inlen,
-    const(ubyte)* key,
-    size_t keylen);
+    scope const(ubyte)* key,
+    size_t keylen) pure;
+
+/// @safe wrapper around `crypto_generichash`
+extern(D) int crypto_generichash (
+    scope ubyte[] out_,
+    scope const ubyte[] in_,
+    scope const ubyte[] key) @trusted pure
+{
+    return crypto_generichash(
+        out_.ptr, out_.length,
+        in_.ptr, in_.length,
+        key.ptr, key.length);
+}
 
 int crypto_generichash_init (
-    crypto_generichash_state* state,
-    const(ubyte)* key,
+    scope crypto_generichash_state* state,
+    scope const(ubyte)* key,
     const size_t keylen,
-    const size_t outlen);
+    const size_t outlen) pure;
+
+/// @safe wrapper around `crypto_generichash_init`
+extern(D) int crypto_generichash_init (
+    scope ref crypto_generichash_state state,
+    scope const(ubyte)[] key,
+    size_t outlen) @trusted pure
+{
+    return crypto_generichash_init(&state, key.ptr, key.length, outlen);
+}
 
 int crypto_generichash_update (
-    crypto_generichash_state* state,
-    const(ubyte)* in_,
-    ulong inlen);
+    scope crypto_generichash_state* state,
+    scope const(ubyte)* in_,
+    ulong inlen) pure;
+
+/// @safe wrapper around `crypto_generichash_update`
+extern(D) int crypto_generichash_update (
+    scope ref crypto_generichash_state state,
+    scope const(ubyte)[] in_) @trusted pure
+{
+    return crypto_generichash_update(&state, in_.ptr, in_.length);
+}
 
 int crypto_generichash_final (
-    crypto_generichash_state* state,
-    ubyte* out_,
-    const size_t outlen);
+    scope crypto_generichash_state* state,
+    scope ubyte* out_,
+    const size_t outlen) pure;
 
-void crypto_generichash_keygen (ref ubyte[crypto_generichash_KEYBYTES] k);
+/// @safe wrapper around `crypto_generichash_final`
+extern(D) int crypto_generichash_final (
+    scope ref crypto_generichash_state state,
+    scope ubyte[] out_) @trusted pure
+{
+    return crypto_generichash_final(&state, out_.ptr, out_.length);
+}
+
+void crypto_generichash_keygen (ref ubyte[crypto_generichash_KEYBYTES] k) @safe;


### PR DESCRIPTION
Hashing is pure (except for the key generation), and we can trivially
wrap those function and provide safe alternatives.